### PR TITLE
ci: add job to run auxiliary lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ on:
   pull_request:
 
 jobs:
-  check-msrv:
+  lint-aux:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Check MSRV in Cargo.toml
-        run: ./ci/check-msrv.sh
+      - name: Install dependencies
+        run: ./ci/install-lint-deps.sh
+      - name: Run auxilary lints
+        run: ./ci/lint-aux.sh
 
   rustfmt:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A library to render snippets of source code with annotations.
 
 Licensed under either of
 
-  * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-    http://www.apache.org/licenses/LICENSE-2.0)
-  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-    http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A library to render snippets of source code with annotations.
 Licensed under either of
 
 * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  <http://www.apache.org/licenses/LICENSE-2.0>)
+  <https://www.apache.org/licenses/LICENSE-2.0>)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-  <http://opensource.org/licenses/MIT>)
+  <https://opensource.org/licenses/MIT>)
 
 at your option.

--- a/ci/install-lint-deps.sh
+++ b/ci/install-lint-deps.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends shellcheck
+
+sudo gem install mdl

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -5,9 +5,9 @@ rust_version="$1"
 shift
 
 if [[ "$rust_version" = *.txt ]]; then
-  rust_version="$(cat ci/rust-versions/$rust_version)"
+  rust_version="$(cat "ci/rust-versions/$rust_version")"
 fi
 
 echo "Installing Rust $rust_version"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$rust_version" "$@"
-echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/ci/lint-aux.sh
+++ b/ci/lint-aux.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "Checking MSRV consistency"
+
 msrv="$(cat ci/rust-versions/msrv.txt)"
 msrv="${msrv%.*}"
 
@@ -13,3 +15,9 @@ if [ "$(grep rust-version Cargo.toml)" != "rust-version = \"$msrv\"" ]; then
   echo "Incorrect rust-version in Cargo.toml"
   exit 1
 fi
+
+echo "Checking shell scripts with shellcheck"
+find . -type f -name "*.sh" -not -path "./.git/*" -print0 | xargs -0 shellcheck
+
+echo "Checking markdown documents with markdownlint"
+find . -type f -name "*.md" -not -path "./.git/*" -print0 | xargs -0 mdl


### PR DESCRIPTION
Uses markdownlint and shellcheck. MSRV consistency checks are now part of this job.

Also includes fixes for warnings in shell scripts and markdown documents detected by the linters.