### PR TITLE
feat!: treat "\r\n" as a line break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "sourceannot"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "indoc",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourceannot"
-version = "0.1.1"
+version = "0.2.0-pre"
 authors = ["Eduardo Sánchez Muñoz <eduardosm-dev@e64.io>"]
 edition = "2021"
 rust-version = "1.74"
@@ -9,7 +9,7 @@ repository = "https://github.com/eduardosm/rust-sourceannot"
 license = "MIT OR Apache-2.0"
 keywords = ["annotation", "code", "error", "report"]
 exclude = ["/.github", ".gitignore", "/ci"]
-publish = true
+publish = false
 
 [dependencies]
 unicode-width = "0.1.11"

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -296,6 +296,40 @@ fn test_render_multi_line_3() {
 }
 
 #[test]
+fn test_render_multi_line_crlf() {
+    let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
+    let snippet = SourceSnippet::build_from_utf8(1, source.as_bytes(), 4);
+
+    let mut annots = Annotations::new(&snippet, MAIN_STYLE);
+    annots.add_annotation(1..14, ANNOT_STYLE_1, vec![("test".into(), '1')]);
+
+    let rendered = annots.render(1, 0, 0);
+    let text: String = rendered.iter().map(|(s, _)| s.as_str()).collect();
+    let styles = gather_styles(&rendered);
+
+    assert_eq!(
+        text,
+        indoc::indoc! {"
+            1 │   1234
+              │ ╭──^
+              · │ 
+            3 │ │ 90ab
+              │ ╰──^ test
+        "},
+    );
+    assert_eq!(
+        styles,
+        indoc::indoc! {"
+            msmssstaaas
+            ssmslllls
+            ssmslss
+            msmslsaatts
+            ssmslllls1111s
+        "},
+    );
+}
+
+#[test]
 fn test_render_zero_len_span() {
     let source = "1234\n5678\n90ab\ncdef\n";
     let snippet = SourceSnippet::build_from_utf8(1, source.as_bytes(), 4);


### PR DESCRIPTION
Previously, it was treated as a control character followed by a line break.