### PR TITLE
feat!: add `SnippetBuilder::maybe_push_control_char` and use it in `Snippet::build_from_utf8` and `Snippet::build_from_latin1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - `SourceSnippet` has been renamed to `Snippet`.
 - `SnippetBuilder` has been added to build custom `Snippet`s.
 - `Snippet::get_line_col()` has been removed.
+- `Snipper::build_from_utf8_ex()` and `Snippet::build_from_latin1_ex()` functions
+  have been removed.
+- `Snipper::build_from_utf8()` and `Snippet::build_from_latin1()` now allow choosing
+  how control characters and invalid UTF-8 sequences are represented.
 - A new `std` feature, which depends on libstd has been enabled. Default features
   need to be disabled to support `no_std`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,15 @@
 //! "#};
 //!
 //! // Create the snippet
-//! let snippet = sourceannot::Snippet::build_from_utf8(1, source.as_bytes(), 4);
+//! let snippet = sourceannot::Snippet::build_from_utf8(
+//!     1,
+//!     source.as_bytes(),
+//!     4,
+//!     sourceannot::ControlCharStyle::Hexadecimal,
+//!     true,
+//!     sourceannot::InvalidUtf8SeqStyle::Hexadecimal,
+//!     true,
+//! );
 //!
 //! // Styles are generic over the type of the metadata that accompanies each
 //! // chunk of rendered text. In this example, we will use the following enum:
@@ -125,7 +133,7 @@ mod range_set;
 mod snippet;
 
 pub use annots::Annotations;
-pub use snippet::Snippet;
+pub use snippet::{ControlCharStyle, InvalidUtf8SeqStyle, Snippet, SnippetBuilder};
 
 /// Trait that consumes a rendered annotated snippet.
 pub trait Output<M> {

--- a/src/snippet/latin1.rs
+++ b/src/snippet/latin1.rs
@@ -1,70 +1,47 @@
-use alloc::format;
-use alloc::string::String;
-
-use super::Snippet;
+use super::{ControlCharStyle, Snippet};
 
 impl Snippet {
     /// Creates a snippet from a Latin-1 (ISO 8859-1) source.
     ///
     /// "\n" and "\r\n" are treated as line breaks.
-    ///
-    /// Control characters (except tabs and line breaks) are represented as
-    /// `<XX>` as alternative text.
-    pub fn build_from_latin1(start_line: usize, source: &[u8], tab_width: usize) -> Self {
-        Self::build_from_latin1_ex(start_line, source, |chr| {
-            if chr == b'\t' {
-                (false, " ".repeat(tab_width))
-            } else {
-                (true, format!("<{chr:02X}>"))
-            }
-        })
-    }
-
-    /// Creates a snippet from a Latin-1 (ISO 8859-1) source.
-    ///
-    /// "\n" and "\r\n" are treated as line breaks.
-    ///
-    /// `on_control` is used to handle control characters (that are not line
-    /// breaks). `on_control` also returns a boolean to indicate if the text
-    /// should be rendered as alternative.
-    ///
-    /// `on_control` should not return a string that contains tabs, line breaks
-    /// or any other control characters.
-    pub fn build_from_latin1_ex<FnCtrl>(
+    pub fn build_from_latin1(
         start_line: usize,
         source: &[u8],
-        mut on_control: FnCtrl,
-    ) -> Self
-    where
-        FnCtrl: FnMut(u8) -> (bool, String),
-    {
-        let mut snippet = Snippet::builder(start_line);
+        tab_width: usize,
+        control_char_style: ControlCharStyle,
+        control_char_alt: bool,
+    ) -> Self {
+        let mut builder = Snippet::builder(start_line);
 
         let mut chars = source.iter();
         while let Some(&chr) = chars.next() {
             if chr == b'\r' && chars.as_slice().starts_with(b"\n") {
-                snippet.next_line(2);
+                builder.next_line(2);
                 chars.next().unwrap();
             } else if chr == b'\n' {
-                snippet.next_line(1);
-            } else if matches!(chr, b' '..=b'~' | 0xA0..=0xFF) {
-                snippet.push_char(chr.into(), 1, false);
+                builder.next_line(1);
             } else {
-                let (alt, text) = on_control(chr);
-                snippet.push_str(&text, 1, alt);
+                let is_control = builder.maybe_push_control_char(
+                    chr.into(),
+                    1,
+                    tab_width,
+                    control_char_style,
+                    control_char_alt,
+                );
+                if !is_control {
+                    builder.push_char(chr.into(), 1, false);
+                }
             }
         }
 
-        snippet.finish()
+        builder.finish()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
-
     use crate::range_set::RangeSet;
-    use crate::snippet::{Snippet, SnippetLine, UnitMeta};
+    use crate::snippet::{ControlCharStyle, Snippet, SnippetLine, UnitMeta};
 
     fn meta(width: u8, len: u8) -> UnitMeta {
         UnitMeta::new(width, len)
@@ -77,7 +54,7 @@ mod tests {
     #[test]
     fn test_simple_1() {
         let source = b"123\n456";
-        let snippet = Snippet::build_from_latin1_ex(0, source, |_| unreachable!());
+        let snippet = Snippet::build_from_latin1(0, source, 4, ControlCharStyle::Hexadecimal, true);
 
         assert_eq!(snippet.start_line, 0);
         assert_eq!(
@@ -111,7 +88,7 @@ mod tests {
     #[test]
     fn test_simple_2() {
         let source = b"123\n456\n";
-        let snippet = Snippet::build_from_latin1_ex(0, source, |_| unreachable!());
+        let snippet = Snippet::build_from_latin1(0, source, 4, ControlCharStyle::Hexadecimal, true);
 
         assert_eq!(snippet.start_line, 0);
         assert_eq!(
@@ -150,7 +127,7 @@ mod tests {
     #[test]
     fn test_non_ascii_chr() {
         let source = b"123\n4\xFF6";
-        let snippet = Snippet::build_from_latin1_ex(0, source, |_| unreachable!());
+        let snippet = Snippet::build_from_latin1(0, source, 4, ControlCharStyle::Hexadecimal, true);
 
         assert_eq!(snippet.start_line, 0);
         assert_eq!(
@@ -184,7 +161,7 @@ mod tests {
     #[test]
     fn test_control_chr() {
         let source = b"123\n4\x806";
-        let snippet = Snippet::build_from_latin1(0, source, 4);
+        let snippet = Snippet::build_from_latin1(0, source, 4, ControlCharStyle::Hexadecimal, true);
 
         assert_eq!(snippet.start_line, 0);
         assert_eq!(
@@ -218,8 +195,7 @@ mod tests {
     #[test]
     fn test_crlf() {
         let source = b"123\r\n4\r6\r\n";
-        let snippet =
-            Snippet::build_from_latin1_ex(0, source, |chr| (true, format!("<{chr:02X}>")));
+        let snippet = Snippet::build_from_latin1(0, source, 4, ControlCharStyle::Hexadecimal, true);
 
         assert_eq!(snippet.start_line, 0);
         assert_eq!(
@@ -260,7 +236,7 @@ mod tests {
     #[test]
     fn test_tabs() {
         let source = b"123\n\t456";
-        let snippet = Snippet::build_from_latin1(0, source, 4);
+        let snippet = Snippet::build_from_latin1(0, source, 4, ControlCharStyle::Hexadecimal, true);
 
         assert_eq!(snippet.start_line, 0);
         assert_eq!(
@@ -290,24 +266,5 @@ mod tests {
                 meta(1, 1),
             ],
         );
-    }
-
-    #[test]
-    fn test_large_meta() {
-        let source = b"1\x002";
-        let snippet = Snippet::build_from_latin1_ex(0, source, |_| (true, "\u{A7}".repeat(150)));
-
-        assert_eq!(snippet.start_line, 0);
-        assert_eq!(
-            snippet.lines,
-            [SnippetLine {
-                text: format!("1{}2", "\u{A7}".repeat(150)).into_boxed_str(),
-                alts: RangeSet::from(1..=300),
-            }],
-        );
-        assert_eq!(snippet.line_map, []);
-        assert_eq!(snippet.metas, [meta(1, 1), meta(0x7F, 0x7F), meta(1, 1)]);
-        assert_eq!(snippet.large_widths, [(1, 150)]);
-        assert_eq!(snippet.large_utf8_lens, [(1, 300)]);
     }
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -7,7 +7,9 @@
 )]
 #![forbid(unsafe_code)]
 
-use sourceannot::{AnnotStyle, Annotations, MainStyle, MarginStyle, Snippet};
+use sourceannot::{
+    AnnotStyle, Annotations, ControlCharStyle, InvalidUtf8SeqStyle, MainStyle, MarginStyle, Snippet,
+};
 
 const MAIN_STYLE: MainStyle<char> = MainStyle {
     margin: Some(MarginStyle {
@@ -63,7 +65,15 @@ impl sourceannot::Output<char> for &mut TestOutput {
 #[test]
 fn test_render_single_line_1() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..4, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -94,7 +104,15 @@ fn test_render_single_line_1() {
 #[test]
 fn test_render_single_line_2() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..4, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -132,7 +150,15 @@ fn test_render_single_line_2() {
 #[test]
 fn test_render_single_line_3() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(0..2, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -168,7 +194,15 @@ fn test_render_single_line_3() {
 #[test]
 fn test_render_single_line_4() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..2, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -206,7 +240,15 @@ fn test_render_single_line_4() {
 #[test]
 fn test_render_multi_line_1() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..12, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -243,7 +285,15 @@ fn test_render_multi_line_1() {
 #[test]
 fn test_render_multi_line_2() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(0..11, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -285,7 +335,15 @@ fn test_render_multi_line_2() {
 #[test]
 fn test_render_multi_line_3() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(0..18, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -327,7 +385,15 @@ fn test_render_multi_line_3() {
 #[test]
 fn test_render_multi_line_4() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(0..7, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -369,7 +435,15 @@ fn test_render_multi_line_4() {
 #[test]
 fn test_render_multi_line_crlf() {
     let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..14, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -406,7 +480,15 @@ fn test_render_multi_line_crlf() {
 #[test]
 fn test_render_single_line_within_multi_line() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..12, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -446,7 +528,15 @@ fn test_render_single_line_within_multi_line() {
 #[test]
 fn test_render_zero_len_span() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..1, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -477,7 +567,15 @@ fn test_render_zero_len_span() {
 #[test]
 fn test_render_tab() {
     let source = "1234\n\t5678\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..3, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);
@@ -513,7 +611,15 @@ fn test_render_tab() {
 #[test]
 fn test_render_line_break_lf_1() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(4..5, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -544,7 +650,15 @@ fn test_render_line_break_lf_1() {
 #[test]
 fn test_render_line_break_lf_2() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(3..5, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -575,7 +689,15 @@ fn test_render_line_break_lf_2() {
 #[test]
 fn test_render_line_break_crlf_1() {
     let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(4..5, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -606,7 +728,15 @@ fn test_render_line_break_crlf_1() {
 #[test]
 fn test_render_line_break_crlf_2() {
     let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(5..6, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -637,7 +767,15 @@ fn test_render_line_break_crlf_2() {
 #[test]
 fn test_render_line_break_crlf_3() {
     let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(4..6, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -668,7 +806,15 @@ fn test_render_line_break_crlf_3() {
 #[test]
 fn test_render_line_break_crlf_4() {
     let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(3..5, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -699,7 +845,15 @@ fn test_render_line_break_crlf_4() {
 #[test]
 fn test_render_line_break_crlf_5() {
     let source = "1234\r\n5678\r\n90ab\r\ncdef\r\n";
-    let snippet = Snippet::build_from_utf8(1, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        1,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(3..6, ANNOT_STYLE_1, vec![("test".into(), '1')]);
@@ -730,7 +884,15 @@ fn test_render_line_break_crlf_5() {
 #[test]
 fn test_render_line_numbers() {
     let source = "1234\n5678\n90ab\ncdef\n";
-    let snippet = Snippet::build_from_utf8(99, source.as_bytes(), 4);
+    let snippet = Snippet::build_from_utf8(
+        99,
+        source.as_bytes(),
+        4,
+        ControlCharStyle::Hexadecimal,
+        true,
+        InvalidUtf8SeqStyle::Hexadecimal,
+        true,
+    );
 
     let mut annots = Annotations::new(&snippet, MAIN_STYLE);
     annots.add_annotation(1..4, ANNOT_STYLE_1, vec![("test 1".into(), '1')]);


### PR DESCRIPTION


`Snippet::build_from_utf8_ex` and `Snippet::build_from_latin1_ex` have been removed.